### PR TITLE
migrationにActiveRecordのバージョンをつける

### DIFF
--- a/db/migrate/20151215115343_sessions.rb
+++ b/db/migrate/20151215115343_sessions.rb
@@ -1,4 +1,4 @@
-class Sessions < ActiveRecord::Migration
+class Sessions < ActiveRecord::Migration[4.2]
   def change
     create_table :sessions do |t|
       t.string :name

--- a/db/migrate/20160428133303_drop_sessions.rb
+++ b/db/migrate/20160428133303_drop_sessions.rb
@@ -1,4 +1,4 @@
-class DropSessions < ActiveRecord::Migration
+class DropSessions < ActiveRecord::Migration[4.2]
   def change
     drop_table :sessions
   end

--- a/db/migrate/20160428134925_create_accounts.rb
+++ b/db/migrate/20160428134925_create_accounts.rb
@@ -1,4 +1,4 @@
-class CreateAccounts < ActiveRecord::Migration
+class CreateAccounts < ActiveRecord::Migration[4.2]
   def change
     create_table :accounts do |t|
       t.string :kmcid

--- a/db/migrate/20160428144917_create_illusts.rb
+++ b/db/migrate/20160428144917_create_illusts.rb
@@ -1,4 +1,4 @@
-class CreateIllusts < ActiveRecord::Migration
+class CreateIllusts < ActiveRecord::Migration[4.2]
   def change
     create_table :illusts do |t|
       t.string :title

--- a/db/migrate/20160428151706_create_comments.rb
+++ b/db/migrate/20160428151706_create_comments.rb
@@ -1,4 +1,4 @@
-class CreateComments < ActiveRecord::Migration
+class CreateComments < ActiveRecord::Migration[4.2]
   def change
 
     create_table :commnets do |t|

--- a/db/migrate/20160428152255_change_table_name_comments.rb
+++ b/db/migrate/20160428152255_change_table_name_comments.rb
@@ -1,4 +1,4 @@
-class ChangeTableNameComments < ActiveRecord::Migration
+class ChangeTableNameComments < ActiveRecord::Migration[4.2]
   def change
     rename_table :commnets, :comments
   end

--- a/db/migrate/20160428213136_change_tablename_illusts_tags.rb
+++ b/db/migrate/20160428213136_change_tablename_illusts_tags.rb
@@ -1,4 +1,4 @@
-class ChangeTablenameIllustsTags < ActiveRecord::Migration
+class ChangeTablenameIllustsTags < ActiveRecord::Migration[4.2]
   def change
     rename_table :illusts_tags, :illust_tags
   end

--- a/db/migrate/20160428213841_change_table_name_illusts_tags.rb
+++ b/db/migrate/20160428213841_change_table_name_illusts_tags.rb
@@ -1,4 +1,4 @@
-class ChangeTableNameIllustsTags < ActiveRecord::Migration
+class ChangeTableNameIllustsTags < ActiveRecord::Migration[4.2]
   def change
     rename_table :illust_tags, :Illust_tag
   end

--- a/db/migrate/20160429042520_rename_table_illusttag.rb
+++ b/db/migrate/20160429042520_rename_table_illusttag.rb
@@ -1,4 +1,4 @@
-class RenameTableIllusttag < ActiveRecord::Migration
+class RenameTableIllusttag < ActiveRecord::Migration[4.2]
   def change
     rename_table :Illust_tag, :illust_tags
   end

--- a/db/migrate/20160506115113_addcolumn_lastlogin.rb
+++ b/db/migrate/20160506115113_addcolumn_lastlogin.rb
@@ -1,4 +1,4 @@
-class AddcolumnLastlogin < ActiveRecord::Migration
+class AddcolumnLastlogin < ActiveRecord::Migration[4.2]
   def change
     add_column :accounts, :lastlogin,:time
   end

--- a/db/migrate/20160506132413_changecolumn_lastlogin.rb
+++ b/db/migrate/20160506132413_changecolumn_lastlogin.rb
@@ -1,4 +1,4 @@
-class ChangecolumnLastlogin < ActiveRecord::Migration
+class ChangecolumnLastlogin < ActiveRecord::Migration[4.2]
   def change
     change_column :accounts, :lastlogin,:datetime
   end

--- a/db/migrate/20160509165212_createtable_likes.rb
+++ b/db/migrate/20160509165212_createtable_likes.rb
@@ -1,4 +1,4 @@
-class CreatetableLikes < ActiveRecord::Migration
+class CreatetableLikes < ActiveRecord::Migration[4.2]
   def change
 
     create_table :likes do |t|

--- a/db/migrate/20160509181031_change_table_likes.rb
+++ b/db/migrate/20160509181031_change_table_likes.rb
@@ -1,4 +1,4 @@
-class ChangeTableLikes < ActiveRecord::Migration
+class ChangeTableLikes < ActiveRecord::Migration[4.2]
   def change
 
     change_table :likes do |t|

--- a/db/migrate/20160613150115_create_folders.rb
+++ b/db/migrate/20160613150115_create_folders.rb
@@ -1,4 +1,4 @@
-class CreateFolders < ActiveRecord::Migration
+class CreateFolders < ActiveRecord::Migration[4.2]
   def change
 
     create_table :folders do |t|

--- a/db/migrate/20160613162145_createtable_folders_tags.rb
+++ b/db/migrate/20160613162145_createtable_folders_tags.rb
@@ -1,4 +1,4 @@
-class CreatetableFoldersTags < ActiveRecord::Migration
+class CreatetableFoldersTags < ActiveRecord::Migration[4.2]
   def change
 
     create_table :folderstags do |t|

--- a/db/migrate/20160614155755_commentbelongs_tofolder.rb
+++ b/db/migrate/20160614155755_commentbelongs_tofolder.rb
@@ -1,4 +1,4 @@
-class CommentbelongsTofolder < ActiveRecord::Migration
+class CommentbelongsTofolder < ActiveRecord::Migration[4.2]
   def change
   end
 end


### PR DESCRIPTION
migrationの継承元クラスにActiveRecordのバージョンを明示しないと怒られるようになっていた

```
Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class Sessions < ActiveRecord::Migration[4.2]
/Users/utgwkk/.ghq/github.com/kmc-jp/GodUploader/db/migrate/20151215115343_sessions.rb:1:in `<top (required)>'
/Users/utgwkk/.rbenv/versions/2.6.1/bin/bundle:23:in `load'
/Users/utgwkk/.rbenv/versions/2.6.1/bin/bundle:23:in `<main>'
```