### PR TITLE
クエリ最適化

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -445,19 +445,10 @@ get '/' do
                             .select{ |a| a.folders.size > 0 }
                             .sort_by{ |a| a.folders.size * -1 }
 
-  hidetags_repr = hidetags.map {|t| '"' + t + '"'}.join ','
   @newerillusts = Folder.distinct
-                        .includes(:illusts)
-                        .includes(:account)
+                        .includes(:illusts, :account)
                         .left_joins(:tags)
-                        .joins(%|
-                          inner join tags t
-                          on tags.id is null
-                          or (
-                            tags.id = t.id
-                            and t.name not in (#{hidetags_repr})
-                          )
-                        |)
+                        .where('tags.name is null or tags.name not in (?)', hidetags)
                         .order("id DESC")
                         .limit(8)
   a = user

--- a/app.rb
+++ b/app.rb
@@ -438,13 +438,26 @@ get '/' do
 
   create_account
 
-  @active_accounts = Account.all.includes(:folders).select{ |a| a.folders.size > 0 }.sort_by{ |a| a.folders.size * -1 }
+  @active_accounts = Account.all
+                            .includes(:folders)
+                            .select{ |a| a.folders.size > 0 }
+                            .sort_by{ |a| a.folders.size * -1 }
   
-  @newerillusts = Folder.distinct.includes(:illusts).joins(:tags).includes(:account).order( "folders.id DESC" ).where("tags.name not in (#{'?' * hidetags.size})", *hidetags).limit(8)
+  @newerillusts = Folder.distinct
+                        .includes(:illusts)
+                        .joins(:tags)
+                        .includes(:account)
+                        .order("folders.id DESC")
+                        .where("tags.name not in (#{'?' * hidetags.size})", *hidetags)
+                        .limit(8)
   a = user
-  @newcomments = Comment.where( "created_at >= ?" , a.lastlogin ).select{ |item| item.account.kmcid != kmcid && item.folder.account.kmcid == kmcid }.uniq
+  @newcomments = Comment.where( "created_at >= ?" , a.lastlogin )
+                        .select{ |item| item.account.kmcid != kmcid && item.folder.account.kmcid == kmcid }
+                        .uniq
 
-  @newlikes = Folder.joins(:likes).where("folders.account_id = ? and likes.account_id <> ? and likes.created_at >= ?", a.id, a.id, a.lastlogin).map {|f| [f, f.likes]}
+  @newlikes = Folder.joins(:likes)
+                    .where("folders.account_id = ? and likes.account_id <> ? and likes.created_at >= ?", a.id, a.id, a.lastlogin)
+                    .map {|f| [f, f.likes]}
 
   a.lastlogin = Time.now
   a.save

--- a/app.rb
+++ b/app.rb
@@ -23,7 +23,6 @@ ActiveRecord::Base.establish_connection(
   adapter: 'sqlite3',
   database: 'god.db'
 )
-ActiveRecord::Base.logger = Logger.new STDOUT
 
 configure do
   use Rack::Session::Cookie,

--- a/app.rb
+++ b/app.rb
@@ -199,6 +199,8 @@ get '/searchbytag/:tagid' do
 
   @tag = Tag.includes(:folders).find_by_id( params[:tagid] )
   @folders = @tag.folders
+                 .includes(:account, :illusts, :tags)
+                 .order("created_at DESC")
 
   erb :searchbytag
 

--- a/app.rb
+++ b/app.rb
@@ -444,12 +444,10 @@ get '/' do
                             .sort_by{ |a| a.folders.size * -1 }
   
   @newerillusts = Folder.distinct
-                        .includes(:illusts)
-                        .joins(:tags)
-                        .includes(:account)
-                        .order("folders.id DESC")
-                        .where("tags.name not in (#{'?' * hidetags.size})", *hidetags)
-                        .limit(8)
+                        .joins(:illusts)
+                        .includes(:tags)
+                        .order( "id DESC" )
+                        .reject{ |f| ishide(f) }.slice(0,8)
   a = user
   @newcomments = Comment.where( "created_at >= ?" , a.lastlogin )
                         .select{ |item| item.account.kmcid != kmcid && item.folder.account.kmcid == kmcid }

--- a/app.rb
+++ b/app.rb
@@ -438,20 +438,13 @@ get '/' do
 
   create_account
 
-  @accounts = Account.all
+  @active_accounts = Account.all.includes(:folders).select{ |a| a.folders.size > 0 }.sort_by{ |a| a.folders.size * -1 }
   
-  @newerillusts = Folder.joins(:illusts).includes(:tags).order( "created_at DESC" ).select{ |f| !ishide(f) }.uniq.slice(0,8)
+  @newerillusts = Folder.distinct.includes(:illusts).joins(:tags).includes(:account).order( "folders.id DESC" ).where("tags.name not in (#{'?' * hidetags.size})", *hidetags).limit(8)
   a = user
   @newcomments = Comment.where( "created_at >= ?" , a.lastlogin ).select{ |item| item.account.kmcid != kmcid && item.folder.account.kmcid == kmcid }.uniq
 
-  @newlikes = []
-  a.folders.each do |f|
-    p f.illusts
-    likes =  f.likes.where( "created_at >= ?" , a.lastlogin ).select{ |item| item.account.kmcid != kmcid && item.folder.account.kmcid == kmcid }.uniq
-    if likes.count > 0 then
-      @newlikes.push( [f,likes] )
-    end
-  end
+  @newlikes = Folder.joins(:likes).where("folders.account_id = ? and likes.account_id <> ? and likes.created_at >= ?", a.id, a.id, a.lastlogin).map {|f| [f, f.likes]}
 
   a.lastlogin = Time.now
   a.save

--- a/db/migrate/20191111102632_create_unique_index_account_kmcid.rb
+++ b/db/migrate/20191111102632_create_unique_index_account_kmcid.rb
@@ -1,0 +1,7 @@
+class CreateUniqueIndexAccountKmcid < ActiveRecord::Migration[5.2]
+  def change
+    change_table :accounts do |t|
+      t.index :kmcid, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,71 +10,72 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160614155755) do
+ActiveRecord::Schema.define(version: 2019_11_11_102632) do
 
   create_table "accounts", force: :cascade do |t|
-    t.string   "kmcid"
-    t.string   "name"
+    t.string "kmcid"
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "lastlogin"
+    t.index ["kmcid"], name: "index_accounts_on_kmcid", unique: true
   end
 
   create_table "comments", force: :cascade do |t|
-    t.string   "text"
+    t.string "text"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "account_id"
-    t.integer  "illust_id"
-    t.integer  "folder_id"
+    t.integer "account_id"
+    t.integer "illust_id"
+    t.integer "folder_id"
   end
 
   create_table "folders", force: :cascade do |t|
-    t.string   "title"
-    t.string   "caption"
-    t.string   "outurl"
-    t.integer  "account_id"
+    t.string "title"
+    t.string "caption"
+    t.string "outurl"
+    t.integer "account_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "folderstags", force: :cascade do |t|
-    t.integer  "folder_id"
-    t.integer  "tag_id"
+    t.integer "folder_id"
+    t.integer "tag_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "illust_tags", force: :cascade do |t|
-    t.integer  "illust_id"
-    t.integer  "tag_id"
+    t.integer "illust_id"
+    t.integer "tag_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "illusts", force: :cascade do |t|
-    t.string   "title"
-    t.string   "caption"
-    t.string   "filename"
+    t.string "title"
+    t.string "caption"
+    t.string "filename"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "account_id"
-    t.integer  "folder_id"
+    t.integer "account_id"
+    t.integer "folder_id"
   end
 
   create_table "likes", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "account_id"
-    t.integer  "illust_id"
-    t.integer  "folder_id"
+    t.integer "account_id"
+    t.integer "illust_id"
+    t.integer "folder_id"
   end
 
   create_table "tags", force: :cascade do |t|
-    t.string   "name"
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "folder_id"
+    t.integer "folder_id"
   end
 
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -69,11 +69,7 @@
           <% @newerillusts.each_with_index do |illust, i| %>
             <div class="col-sm-3">
               <a href="<%= uri("./illust/"+illust.id.to_s ,false) %>" class="thumbnail"  style="width:auto;height:<%= thumbheight %>;">
-                <% if ishide(illust) then %>
-                  検閲によりサムネイル表示なし
-                <% else %>
-                  <img style="width:auto;height:60%;"  src="<%= uri( "./illusts/" + illust.illusts.first.filename , false ) %>"  >
-                <% end %>
+                <img style="width:auto;height:60%;"  src="<%= uri( "./illusts/" + illust.illusts.first.filename , false ) %>"  >
                 <div class="caption">
                   <h3><%= illust.title  %></h3>
                   <p><%= illust.account.name %></p>

--- a/views/index.erb
+++ b/views/index.erb
@@ -66,7 +66,7 @@
     <div class="panel-body">
       <div class="row">
         <div class="col-sm-12">
-          <% @newerillusts.sort!{ |a,b|b.created_at <=> a.created_at }.each_with_index do |illust, i| %>
+          <% @newerillusts.each_with_index do |illust, i| %>
             <div class="col-sm-3">
               <a href="<%= uri("./illust/"+illust.id.to_s ,false) %>" class="thumbnail"  style="width:auto;height:<%= thumbheight %>;">
                 <% if ishide(illust) then %>
@@ -95,7 +95,7 @@
     <div class="panel-body">
       <div class="row">
         <div class="col-md-12">
-          <% @accounts.includes(:folders).select{ |a| a.folders.size > 0 }.sort_by{ |a| a.folders.size * -1 }.each do |a| %>
+          <% @active_accounts.each do |a| %>
             <div class="col-md-3">
               <a href="<%= uri( 'users/' + a.kmcid ,false ) %>" type="button" class="btn btn-default center-block" ><%= a.name %>(<%=a.folders.size%>)</a>
             </div>

--- a/views/searchbytag.erb
+++ b/views/searchbytag.erb
@@ -6,7 +6,7 @@
     </div>
     <div class="panel-body">
       <div class="row"> 
-        <% @folders.includes(:account, :illusts).order("created_at DESC").each do |i| %>
+        <% @folders.each do |i| %>
           <div class="col-md-3">
             <a href="<%= uri("./illust/"+i.id.to_s ,false) %>" class="thumbnail" style="height:<%= thumbheight %>;" >
               <% if ishide(i) then %>


### PR DESCRIPTION
# GET /

- `@newerillusts` 全件取得せずに必要なぶんだけ取得して表示できるようにした
  - ここでは `ishide` が不要になった
  - 確かにトップに出てこないことを確認した
- `@newcomments` と `@newlikes` のN+1解消した

# GET /searchbytag/:tagid

- `ishide` にtagsが必要なのでincludeした

# インデックス

- `accounts.kmcid` にunique keyを追加した

# 速度

GET / について、部内で動いているアプリを書き換えて確かめた

- ストレージの調子にもよるけど遅くても1sはかからなくなったと思う

Chromeの開発者ツールでnetwork眺めた結果。TTFBが短くなってる

## before

```
Queued at 0
--
Started at 1.97 ms
Resource Scheduling |   | DURATION
Queueing | ​ | 1.97 ms
Connection Start |   | DURATION
Stalled | ​ | 1.09 ms
Request/Response |   | DURATION
Request sent | ​ | 0.14 ms
Waiting (TTFB) | ​ | 1.09 s
Content Download | ​ | 2.49 ms
Explanation |   | 1.10 s
```

## after

```
Queued at 0
--
Started at 5.19 ms
Resource Scheduling |   | DURATION
Queueing | ​ | 5.19 ms
Connection Start |   | DURATION
Stalled | ​ | 1.12 ms
Request/Response |   | DURATION
Request sent | ​ | 0.17 ms
Waiting (TTFB) | ​ | 455.01 ms
Content Download | ​ | 2.44 ms
Explanation |   | 463.93 ms
```