### PR TITLE
filename = nilのときindexページがTypeErrorになるのをひとまず回避

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -69,7 +69,7 @@
           <% @newerillusts.each_with_index do |illust, i| %>
             <div class="col-sm-3">
               <a href="<%= uri("./illust/"+illust.id.to_s ,false) %>" class="thumbnail"  style="width:auto;height:<%= thumbheight %>;">
-                <img style="width:auto; height:<%= thumbnail_image_height %>px; object-fit: contain;"  src="<%= uri( "./thumbnail/" + illust.illusts.first.filename , false ) %>"  >
+                <img style="width:auto; height:<%= thumbnail_image_height %>px; object-fit: contain;"  src="<%= uri( "./thumbnail/#{illust.illusts.first.filename}", false ) %>"  >
                 <div class="caption">
                   <h3><%= illust.title  %></h3>
                   <p><%= illust.account.name %></p>


### PR DESCRIPTION
indexページを開くとISEになり、passengerのログに以下のようなスタックトレースが出力されてました

```
2020-06-20 18:52:02 - TypeError - no implicit conversion of nil into String:
       /home/passenger/GodUploader/views/index.erb:72:in `+'
(省略)
```

ここで `"./thumbnail/" + illust.illusts.first.filename` してるけど、右辺が `nil` になっているぽい？ https://github.com/kmc-jp/GodUploader/blob/484c6dbd3a459094e83d8cbee07d6a1cd29c1fe6/views/index.erb#L72

indexページが見えるようになることを優先して、とりあえず文字列連結をやめて式展開するようにしました。ファイルパスとしてはおかしいし、個別イラストのページに飛ぶとISEになるけど、どのみち一次対策みたいなもんです
```
irb(main):001:0> "a.#{nil}"
=> "a."
```

動作確認してないけどたぶんこれでindexページは見えるようになるはず