### PR TITLE
ユーザーの投稿数をaccountモデルに持っておく

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -246,13 +246,14 @@ post '/uploadillust' do
   return 400 unless params[:illusts]
 
   folder = user.folders.build( title:params[:title] , caption:params[:caption] )
-
+  
   # フォルダ作れないのはなんかこっちがおかしい気がするので500
   return 500 unless folder.save
-
+  
   # フォルダできたので投稿数を増やす
-  user.folders_count += 1
-  user.save
+  current_user = user
+  current_user.folders_count += 1
+  current_user.save
 
   params[:tags].split(',').each do |t|
     if !folder.tags.exists?( :name => t ) then
@@ -338,8 +339,9 @@ post '/deleteillust/:id' do
   if Folder.exists?( :id => params[:id].to_i ) then
     Folder.find_by_id( params[:id].to_i ).destroy
     # フォルダなくなったので投稿数を減らす
-    user.folders_count -= 1
-    user.save
+    current_user = user
+    current_user.folders_count -= 1
+    current_user.save
   end
  
   redirect uri( "/users/" + kmcid , false )

--- a/app.rb
+++ b/app.rb
@@ -461,8 +461,8 @@ get '/' do
 
   @active_accounts = Account.all
                             .includes(:folders)
-                            .select{ |a| a.folders.size > 0 }
-                            .sort_by{ |a| a.folders.size * -1 }
+                            .select{ |a| a.folders_count > 0 }
+                            .sort_by{ |a| a.folders_count * -1 }
 
   @newerillusts = Folder.distinct
                         .includes(:illusts, :account)

--- a/app.rb
+++ b/app.rb
@@ -337,6 +337,9 @@ post '/deleteillust/:id' do
 
   if Folder.exists?( :id => params[:id].to_i ) then
     Folder.find_by_id( params[:id].to_i ).destroy
+    # フォルダなくなったので投稿数を減らす
+    user.folders_count -= 1
+    user.save
   end
  
   redirect uri( "/users/" + kmcid , false )

--- a/app.rb
+++ b/app.rb
@@ -467,7 +467,7 @@ get '/' do
   create_account
 
   @active_accounts = Account.all
-                            .select{ |a| a.folders_count > 0 }
+                            .where('folders_count > 0')
                             .sort_by{ |a| a.folders_count * -1 }
 
   @newerillusts = Folder.distinct

--- a/app.rb
+++ b/app.rb
@@ -468,7 +468,7 @@ get '/' do
 
   @active_accounts = Account.all
                             .where('folders_count > 0')
-                            .sort_by{ |a| a.folders_count * -1 }
+                            .order('folders_count DESC')
 
   @newerillusts = Folder.distinct
                         .includes(:illusts, :account)

--- a/app.rb
+++ b/app.rb
@@ -460,7 +460,6 @@ get '/' do
   create_account
 
   @active_accounts = Account.all
-                            .includes(:folders)
                             .select{ |a| a.folders_count > 0 }
                             .sort_by{ |a| a.folders_count * -1 }
 

--- a/app.rb
+++ b/app.rb
@@ -250,6 +250,10 @@ post '/uploadillust' do
   # フォルダ作れないのはなんかこっちがおかしい気がするので500
   return 500 unless folder.save
 
+  # フォルダできたので投稿数を増やす
+  user.folders_count += 1
+  user.save
+
   params[:tags].split(',').each do |t|
     if !folder.tags.exists?( :name => t ) then
       if Tag.exists?( :name => t ) then

--- a/db/migrate/20201011065435_add_column_folders_count_to_account.rb
+++ b/db/migrate/20201011065435_add_column_folders_count_to_account.rb
@@ -1,0 +1,7 @@
+class AddColumnFoldersCountToAccount < ActiveRecord::Migration[5.2]
+  def change
+    change_table :accounts do |t|
+      t.integer :folders_count, default: 0, null: false
+    end
+  end
+end

--- a/db/migrate/20201011071242_create_index_accounts_folders_count.rb
+++ b/db/migrate/20201011071242_create_index_accounts_folders_count.rb
@@ -1,0 +1,7 @@
+class CreateIndexAccountsFoldersCount < ActiveRecord::Migration[5.2]
+  def change
+    change_table :accounts do |t|
+      t.index :folders_count
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_11_065435) do
+ActiveRecord::Schema.define(version: 2020_10_11_071242) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "kmcid"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2020_10_11_065435) do
     t.datetime "updated_at"
     t.datetime "lastlogin"
     t.integer "folders_count", default: 0, null: false
+    t.index ["folders_count"], name: "index_accounts_on_folders_count"
     t.index ["kmcid"], name: "index_accounts_on_kmcid", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_11_102632) do
+ActiveRecord::Schema.define(version: 2020_10_11_065435) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "kmcid"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2019_11_11_102632) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "lastlogin"
+    t.integer "folders_count", default: 0, null: false
     t.index ["kmcid"], name: "index_accounts_on_kmcid", unique: true
   end
 

--- a/onetime/calculate_and_save_account_folders_count.rb
+++ b/onetime/calculate_and_save_account_folders_count.rb
@@ -1,0 +1,19 @@
+require 'active_record'
+require './models/account.rb'
+require './models/folder.rb'
+
+ActiveRecord::Base.establish_connection(
+  adapter: 'sqlite3',
+  database: 'god.db'
+)
+ActiveRecord::Base.logger = Logger.new(STDOUT)
+
+all_accounts_with_folders = Account.all.includes(:folders)
+
+all_accounts_with_folders.each {|account|
+  folders_count = account.folders.size
+  p [account.kmcid, folders_count]
+
+  account.folders_count = folders_count
+  account.save
+}

--- a/views/index.erb
+++ b/views/index.erb
@@ -93,7 +93,7 @@
         <div class="col-md-12">
           <% @active_accounts.each do |a| %>
             <div class="col-md-3">
-              <a href="<%= uri( 'users/' + a.kmcid ,false ) %>" type="button" class="btn btn-default center-block" ><%= a.name %>(<%=a.folders.size%>)</a>
+              <a href="<%= uri( 'users/' + a.kmcid ,false ) %>" type="button" class="btn btn-default center-block" ><%= a.name %>(<%=a.folders_count%>)</a>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
# 課題

- `GET /` のTTFBが600msぐらいかかっててる
- rack-lineprofを使って見てみると `@active_accounts` を取得する部分で300msぐらいかかってた
  - 全ユーザーを取得して、ユーザーごとの全投稿 (folders) を取得して、 `folders.size > 0` なものを返している
    - 実質的に `accounts` テーブルと `folders` テーブルのフルスキャンになっている

# やったこと

- accountモデルに投稿数 (folders_count) を持たせるようにしました
  - 投稿したら増え、投稿消したら減る
  - インデックスあり
- `@active_accounts` を取得するときのクエリをシンプルなWHERE句にしました
  - `SELECT * FROM accounts WHERE folders_count > 0 ORDER BY folders_count DESC`
- データ投入用のスクリプトを用意しました
  - folders_countを実際のデータから計算して保存する

# 所感

- IOで詰まっていそう？
  - あとで見たところよくなってはいそうだった
  - 効かないということはないと思う
  - `a.save` に時間かかってて大変