### PR TITLE
Slack共有するのは1回だけ・1番目の画像だけにする

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -265,6 +265,8 @@ post '/uploadillust' do
     end
   end
 
+  posted_to_slack = false
+
   params[:illusts].each do |buf|
     illust = folder.illusts.create
 
@@ -308,7 +310,7 @@ post '/uploadillust' do
       end
 
       # Slack共有
-      if params[:isslack] && !params[:channel].nil? then
+      if params[:isslack] && !params[:channel].nil? && !posted_to_slack then
         if params[:isgyazo] then
           gyazo = Gyazo::Client.new access_token: ENV['gyazo_token']
           gyazo_path = "./public/thumbnail/" + folder.illusts.first.filename;  
@@ -321,6 +323,7 @@ post '/uploadillust' do
           folder.save
         end
         upload_post( params[:channel] , folder )
+        posted_to_slack = true
       end
     end
   end

--- a/app.rb
+++ b/app.rb
@@ -291,7 +291,7 @@ post '/uploadillust' do
   # 時間かかるのでthreadに逃がす
   Thread.new do
     # サムネイル生成
-    Folder.illusts.each do |illust|
+    folder.illusts.each do |illust|
       save_path = "./public/illusts/" + illust.filename
       outdir = './public/thumbnail'
       basename = File.basename(save_path).split('.').first


### PR DESCRIPTION
- `params[:illusts].each` のループ内でサムネイル生成とSlack共有をやっているので、投稿したイラストの枚数ぶんだけ先頭の画像がSlack共有されてしまっている
- 画像を保存し終わってからスレッド生成してやってみてます