### PR TITLE
slack-api への依存をなくす

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'sinatra-contrib'
 gem 'rake'
 gem 'erubis'
 gem 'twitter'
-gem 'slack-api'
 gem 'gyazo', '>= 3.0'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,14 +22,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
     erubis (2.7.0)
-    eventmachine (1.2.7)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.1)
-      faraday (>= 0.7.4, < 1.0)
-    faye-websocket (0.10.7)
-      eventmachine (>= 0.12.0)
-      websocket-driver (>= 0.5.1)
     gyazo (3.0.1)
       faraday
       mime-types
@@ -76,11 +70,6 @@ GEM
       rack-protection (= 2.0.5)
       sinatra (= 2.0.5)
       tilt (>= 1.3, < 3)
-    slack-api (1.6.1)
-      faraday (~> 0.11)
-      faraday_middleware (~> 0.10.0)
-      faye-websocket (~> 0.10.6)
-      multi_json (~> 1.0, >= 1.0.3)
     sqlite3 (1.3.13)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -100,9 +89,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    websocket-driver (0.7.0)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
 
 PLATFORMS
   ruby
@@ -115,7 +101,6 @@ DEPENDENCIES
   sinatra
   sinatra-activerecord
   sinatra-contrib
-  slack-api
   sqlite3 (~> 1.3.6)
   twitter
   unf_ext (~> 0.0.7.1)


### PR DESCRIPTION
使ってなさそうだった (incoming webhook叩いてるだけ) し古びていそうだった https://github.com/aki017/slack-ruby-gem
現代は [slack-ruby-client](https://github.com/slack-ruby/slack-ruby-client) っていうのを使うほうがよさそう