### PR TITLE
uuidからファイル名を決める

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,7 @@ require "sinatra/reloader"
 require 'json'
 require 'net/http'
 require 'gyazo'
+require 'securerandom'
 require './models/illust.rb'
 require './models/illust_tag.rb'
 require './models/account.rb'
@@ -266,14 +267,14 @@ post '/uploadillust' do
   end
 
   params[:illusts].each do |buf|
-    illust = folder.illusts.create
-
-    if params[:tegaki] then
-      illust.filename = illust.id.to_s + ".png"
-    else 
-      illust.filename = illust.id.to_s + "." + buf[:filename].split('.').last
-    end
-    illust.save
+    ext =
+      if params[:tegaki]
+        '.png'
+      else
+        buf[:filename].split('.').last
+      end
+    filename = "#{SecureRandom.uuid}.#{ext}"
+    illust = folder.illusts.create(filename: filename)
 
     if !File.exists?( 'public/illusts' )
       Dir.mkdir( 'public/illusts' )

--- a/app.rb
+++ b/app.rb
@@ -269,7 +269,7 @@ post '/uploadillust' do
   params[:illusts].each do |buf|
     ext =
       if params[:tegaki]
-        '.png'
+        'png'
       else
         buf[:filename].split('.').last
       end


### PR DESCRIPTION
- `create` してから `save` するまでの間に例外が送出されたら `filename = NULL` な行ができる
- NULLが混入するといろいろめんどう
- `create` する時点で `SecureRandom.uuid` をもとにファイル名を決めるようにします